### PR TITLE
Fix truncated body

### DIFF
--- a/src/mqtt-client/connection/reader.cr
+++ b/src/mqtt-client/connection/reader.cr
@@ -196,7 +196,7 @@ module MQTT
         value = 0
         loop do
           b = socket.read_byte || raise IO::EOFError.new
-          value = (b & 127) * multiplier
+          value += (b & 127) * multiplier
           multiplier *= 128
           raise "invalid packet length" if multiplier > 128*128*128
           break if b & 128 == 0


### PR DESCRIPTION
I noticed with a "large" payload body (more than 127 bytes), the received message would get truncated. In searching for the reason, I discovered the payload decoder would **overwrite** the value of the remaining length on each loop iteration (oops) thus causing the truncated message.

You can find the reference in the MQTT standard doc by searching for "algorithm for decoding the Remaining Length": https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/mqtt-v3.1.1.html

This _small_ fix ensures the full payload body can be read.