### PR TITLE
Crystal 1.19 fix: Handle deprecated `Time.monotonic`

### DIFF
--- a/spec/mqtt-client_spec.cr
+++ b/spec/mqtt-client_spec.cr
@@ -72,7 +72,13 @@ describe MQTT::Client do
       mqtt.ping
       done.receive
       mqtt.close
-      mqtt.@connection.not_nil!("Connection missing").@reader.@last_packet_received.should be_close Time.monotonic, 1.second
+      connection = mqtt.@connection.should_not be_nil
+      expected = {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}
+                   ::Time.monotonic
+                 {% else %}
+                   ::Time.instant
+                 {% end %}
+      connection.@reader.@last_packet_received.should be_close expected, 1.second
     end
   end
 

--- a/src/mqtt-client/connection/reader.cr
+++ b/src/mqtt-client/connection/reader.cr
@@ -5,7 +5,11 @@ module MQTT
     class Reader
       record Message, packet_id : UInt16, topic : String, body : Bytes, qos : UInt8, retain : Bool, dup : Bool
       getter messages = Channel(Message).new(16)
-      @last_packet_received = Time.monotonic
+      {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}
+        @last_packet_received = Time.monotonic
+      {% else %}
+        @last_packet_received = Time.instant
+      {% end %}
       @connected = true
 
       def initialize(@socket : IO, @acks : Channel(UInt16), @writer : Writer, @keepalive : UInt16)
@@ -55,7 +59,12 @@ module MQTT
       private def maybe_send_ping
         return unless @keepalive.positive?
 
-        now = Time.monotonic
+        now = {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}
+                Time.monotonic
+              {% else %}
+                Time.instant
+              {% end %}
+
         @last_packet_received = now
         if (now - @writer.last_packet_sent).total_seconds > @keepalive * 0.9
           @writer.send PingReq.new
@@ -65,7 +74,12 @@ module MQTT
       private def try_send_ping(ex)
         raise ex unless @keepalive.positive?
 
-        now = Time.monotonic
+        now = {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}
+                Time.monotonic
+              {% else %}
+                Time.instant
+              {% end %}
+
         ping_diff = now - @last_packet_received
         if ping_diff.total_seconds > @keepalive * 1.5
           raise TimeoutError.new("No ping response from server in #{ping_diff}", cause: ex)

--- a/src/mqtt-client/connection/writer.cr
+++ b/src/mqtt-client/connection/writer.cr
@@ -3,7 +3,12 @@ require "./packet"
 module MQTT
   class Client
     class Writer
-      getter last_packet_sent = Time.monotonic
+      {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}
+        getter last_packet_sent = ::Time.monotonic
+      {% else %}
+        getter last_packet_sent = ::Time.instant
+      {% end %}
+
       @packet_id = 0u16
       @requests = Channel(Packet).new(1)
 
@@ -165,7 +170,11 @@ module MQTT
       end
 
       private def update_last_packet_sent
-        @last_packet_sent = Time.monotonic
+        {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}
+          @last_packet_sent = Time.monotonic
+        {% else %}
+          @last_packet_sent = Time.instant
+        {% end %}
       end
 
       private def next_packet_id : UInt16


### PR DESCRIPTION
Use `Time.instant` if crystal version >= 1.19.0.